### PR TITLE
Ensure /opt/rocm/bin is in PATH

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           packages: hipcc
           version: 6.3.0
-      - run: ls /opt/rocm/bin/hipcc
+      - run: which hipcc
 
   install-usecase:
     name: Run ROCm installer with custom usecase

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,9 @@ runs:
       if: "${{ inputs.packages != '' }}"
       shell: bash
       run: sudo apt install -y ${{ inputs.packages }}
+    - name: "Ensure /opt/rocm/bin is in PATH"
+      shell: bash
+      run: echo /opt/rocm/bin >> $GITHUB_PATH
 branding:
   icon: arrow-down-circle
   color: green


### PR DESCRIPTION
When e.g. installing only the hipcc packages, no symlink to from /usr/local/bin/hipcc to /opt/rocm/bin/hipcc is created. To avoid users having to either update PATH themselves or using the absolute path, add /opt/rocm/bin to PATH in the installer.